### PR TITLE
Only use colors when supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Options
 -	`failedSpec: true` - display failed specs;
 -	`failuresSummary: true` - display a summary with the failed specs;
 -	`hideEmptySummary: false` - hide passed/failed/pending in the summary if the corresponding tests number is 0;
--	`inColors: true` - use colors to display the reports;
+-	`inColors: colors.supportsColor` - use colors to display the reports. Turn on if supported;
 -	`indent: '\t'` - the indentation character/string;
 -	`namesInColors: false` - display suite and specs names in colors;
 -	`startingSpec: false` - display started specs;

--- a/src/TerminalLogger.js
+++ b/src/TerminalLogger.js
@@ -8,7 +8,7 @@
       failedSpec:       true,
       failuresSummary:  true,
       hideEmptySummary: false,
-      inColors:         true,
+      inColors:         colors.supportsColor,
       indent:           '\t',
       namesInColors:    false,
       startingSpec:     false,


### PR DESCRIPTION
We run some jasmine tests on a TFS server, and the console there does not support colored output and we have to manually disable colors in this reporter so the output is readable there.

This should properly set the defaults.