### PR TITLE
Use characters supported everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Options
 	-	`system: 'grey'` - color used to display system information (duration, summary, ...);
 -	`symbols`
 	-	`starting: '▻  '.strikethrough` - spec started symbol;
-	-	`failed: '✗  '.strikethrough` - failed spec symbol;
-	-	`passed: '✓  '.strikethrough` - passed spec symbol;
+	-	`failed: 'X  '.strikethrough` - failed spec symbol;
+	-	`passed: '√  '.strikethrough` - passed spec symbol;
 	-	`pending: '~  '.strikethrough` - pending(skipped) spec symbol;
 	-	`disabled: '#  '.strikethrough` - disabled spec symbol;
 	-	`suite: '» '.strikethrough` - suite symbol;

--- a/src/TerminalLogger.js
+++ b/src/TerminalLogger.js
@@ -28,8 +28,8 @@
         system:         'grey'
       },
       symbols: {
-        failed:         colors.strikethrough('✗  '),
-        passed:         colors.strikethrough('✓  '),
+        failed:         colors.strikethrough('X  '),
+        passed:         colors.strikethrough('√  '),
         pending:        colors.strikethrough('~  '),
         disabled:       colors.strikethrough('#  '),
         suite:          colors.strikethrough('»  '),


### PR DESCRIPTION
The proposed changes here use characters are supported by the default Windows fonts ( Consolas, Courier New, etc.) used by the Windows console prompts & Powershell.

Currently the default characters used here are unfortunately not supported by the Consolas and they just render as squares

### Before
**Courier New**
![image](https://cloud.githubusercontent.com/assets/463685/24752903/ef76b868-1a9d-11e7-944a-3c2105d2f94b.png)


I am able to change the font preference to something with support (Source Code Pro), but many users will likely not know how/why to do this and it really should "just  work" with the defaults out of the box.


### After
**Courier New**
![image](https://cloud.githubusercontent.com/assets/463685/24753975/86115cf2-1aa2-11e7-8f5f-eb6830919c0f.png)

**Consolas**
![image](https://cloud.githubusercontent.com/assets/463685/24753825/dbea1778-1aa1-11e7-85aa-b3ff7527eb08.png)
